### PR TITLE
Add AggregateCandles

### DIFF
--- a/cloudbuild_dataflow.yaml
+++ b/cloudbuild_dataflow.yaml
@@ -11,5 +11,7 @@ steps:
     '--temp_location', 'gs://crypto-trading-v2-dataflow/temp',
     '--setup_file', './setup.py',
     '--writer', 'BIGQUERY',
+    '--start', '2014-01-01',
+    '--end', '2023-01-01',
   ]
 

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -1,16 +1,29 @@
 local_env_data = './data'
 symbols = ['BTCUSD']
-timeframes = ['1m']
+timeframes = [
+    '1m',
+    # '5m',
+    # '15m',
+    # '30m',
+    # '1h',
+    # '2h',
+    # '4h',
+    # '6h',
+    # '12h',
+    # '1D',
+    # '2D',
+]
 table = {
-    'imputecandles': 'candles',
+    'aggregatecandles': 'candles',
 }
 schema = {
-    'imputecandles': [
+    'aggregatecandles': [
         {'name': 'timestamp', 'type': 'NUMERIC', 'mode': 'REQUIRED'},
         {'name': 'open', 'type': 'NUMERIC', 'mode': 'REQUIRED'},
         {'name': 'close', 'type': 'NUMERIC', 'mode': 'REQUIRED'},
         {'name': 'high', 'type': 'NUMERIC', 'mode': 'REQUIRED'},
         {'name': 'low', 'type': 'NUMERIC', 'mode': 'REQUIRED'},
+        {'name': 'rank', 'type': 'INT64', 'mode': 'REQUIRED'}
     ]
 }
 default_hist_start = '2022-01-01'

--- a/pipeline/steps/candles/aggregate_candles.py
+++ b/pipeline/steps/candles/aggregate_candles.py
@@ -1,1 +1,43 @@
-# Placeholder script for aggregating candles
+import apache_beam as beam
+from pipeline.utils.utils import timeframe_to_ms
+from copy import deepcopy
+
+class AggregateCandles(beam.DoFn):
+    def __init__(self, timeframe: str):
+        self.timeframe = timeframe
+        self.start_timestamp = None
+        self.base_ms = timeframe_to_ms('1m')
+        self.ms = timeframe_to_ms(timeframe)
+        self.last_candle = None
+        self.rank = 0
+
+    def process(self, element):
+        if self.start_timestamp is None:
+            # start timestamp is currently used to determine when all candle start and end
+            # (by measuring the difference between a new candle's timestamp and the start timestamp)
+            # This could become problematic if for e.g. a timeframe is 1 month but the start timestamp
+            # is in the middle of the month.
+            # TODO: Fix above bug once newer timeframes are introduced
+
+            self.start_timestamp = element['timestamp']
+
+        # Refresh last candles
+        if (element['timestamp'] - self.start_timestamp) % self.ms == 0:
+            self.rank = 0
+            self.last_candle = deepcopy(element)
+            self.last_candle['rank'] = self.rank
+
+        else:
+            # Update candle
+            self.rank += 1
+            updated_candle = deepcopy(self.last_candle)
+            updated_candle['close'] = element['close']
+            updated_candle['rank'] = self.rank
+            if updated_candle['high'] < element['high']:
+                updated_candle['high'] = element['high']
+            if updated_candle['low'] > element['low']:
+                updated_candle['low'] = element['low']
+            
+            self.last_candle = updated_candle
+        
+        yield self.last_candle

--- a/pipeline/steps/candles/fetch_candles.py
+++ b/pipeline/steps/candles/fetch_candles.py
@@ -47,5 +47,5 @@ class FetchCandles(beam.DoFn):
                 }  # exclude volume for now
             
             # Calculate length of time delay to not breach req limit
-            delay = 60 / config.bitfinex['candles']['max_req_per_min']
+            delay = (60 / config.bitfinex['candles']['max_req_per_min']) * len(config.symbols)
             time.sleep(delay)

--- a/pipeline/utils/pipeline_utils.py
+++ b/pipeline/utils/pipeline_utils.py
@@ -31,6 +31,7 @@ class PipelineWriter(beam.PTransform):
         self.text_dest = self.table.replace('.', '-')
         self.bq_dest = self.table
         self.schema = config.schema[self.config_name]
+        self.label = self.table  # Configure pipeline label property
 
     def expand(self, pcoll):
         writer = self._get_writer()

--- a/pipeline/utils/utils.py
+++ b/pipeline/utils/utils.py
@@ -1,5 +1,5 @@
-import time
 from datetime import datetime
+import calendar
 
 
 def date_str_to_timestamp(date_str: str) -> int:
@@ -10,7 +10,7 @@ def date_str_to_timestamp(date_str: str) -> int:
     Returns:
         int: a timestamp conversion of the given date string
     """
-    return int(time.mktime(datetime.strptime(date_str, '%Y-%m-%d').timetuple()) * 1000)
+    return int(calendar.timegm(datetime.strptime(date_str, '%Y-%m-%d').timetuple()) * 1000)
 
 def timeframe_to_ms(timeframe: str) -> int:
     """


### PR DESCRIPTION
- `AggregateCandles`: Aggregates the base 1m candles into larger timeframes: 5m, 15m 1h, 4h etc.

**OUTSTANDING ISSUE**: Dataflow is only autoscaling to 1 worker. How to create N workers for N aggregations? This issue is being addressed in a new PR

For now, aggregate candles step will be merged into main with the drawback that running on dataflow is incredibly slow atm.