### PR TITLE
enhance tasks to read from db and only activate tasks that are necessary

### DIFF
--- a/trading/pipeline/base_classes/source.py
+++ b/trading/pipeline/base_classes/source.py
@@ -1,97 +1,66 @@
-from pipeline.base_classes.base_task import BaseTask
+from pipeline.base_classes.task import tasks_obj
+from pipeline.configs.task_config import ACTIVATED, SOURCE, QUEUED
 from pipeline.configs import config
-from pipeline.utils.row_formatters import Psycopg2Formatter
 import os
-import requests
 
-
-class Source(BaseTask):
+class Source:
     def __init__(self):
-        self.output_element = None
-        self.output_tasks = []
-
-        # Metadata
-        self.task_name = str(type(self).__name__).lower()
-        self.task_id = f'{self.symbol}_{self.task_name}'
-        self.table = f'{self.symbol}_{config.table[self.task_name]}'.lower()
-        self.schema = config.schema[self.task_name]
-        self.fields = [s.split(' ')[0] for s in self.schema]
-        self.env_type = os.getenv('ENV_TYPE')
+        self.active_tasks = {}
+        self._set_task_status()        
+        self.source_tasks = {}
+        self._get_source_tasks()
         self.start = int(os.getenv('PIPELINE_START'))
-        self.end = int(os.getenv('PIPELINE_END'))
-
-        # Progress tracking
+        self.end = int(os.getenv('PIPELINE_END')) - config.base_ms
+        self.current_timestamp = self.start
         self.total_elements = (self.end - self.start) / config.base_ms
         self.elements_complete = 0
         self.percent_complete = 0
 
-        # reading/writing
-        self.write_batch = []
-        self.row_formatter = Psycopg2Formatter(self.task_name)
-        self.data_source = []
-        def default_writer(*args, **kwargs):
+    def start_source(self):
+        if len(self.active_tasks.keys()) == 0:
             return
-        self.data_writer = default_writer
-        if self.env_type == 'dev':
-            table_exists = requests.get(url=f'{config.api_base_url}/exists?table={self.table}').json()['data']
-            if table_exists:
-                datarange = requests.get(url=f'{config.api_base_url}/datarange?table={self.table}').json()['data']
-                if self.start >= int(datarange[0]) and self.end <= int(datarange[-1] + config.base_ms):
-                    # if the data already exists then read from the database
-                    # and don't write
-                    self.data_source = self._db_source()
-                else:
-                    # if the data doesn't exist yet then fetch from exchange api
-                    # and write to database
-                    self.data_source = self.generate()
-                    self.data_writer = self._db_write
-                    self._create_table()
-            else:
-                # also fetch/write to db if the table doesn't exist yet
-                self.data_source = self.generate()
-                self.data_writer = self._db_write
-                self._create_table()
-                
-        super().__init__()
-        
-    def generate(self):
-        # Should be overridden by child class
-        yield 0
+        self._reset_iteration_status()
+        while self.current_timestamp != self.end:
+            self._activate_tasks()
+            self.current_timestamp += config.base_ms
+            self._update_progress()
+            self._reset_iteration_status()
+        for task_id, task in self.source_tasks.items():
+            task.kill_all()
 
-    def activate(self):  
-        for element in self.data_source:
-            if element is not None and self.output_element is not None \
-                and element['timestamp'] != self.output_element['timestamp'] + config.base_ms:
-                raise Exception(
-                    f'''
-                    Error: expected timestamp {str(self.output_element["timestamp"] + config.base_ms)} 
-                    but received {str(self.element['timestamp'])}
-                    '''
-                )
-            self.output_element = element
+    def _reset_iteration_status(self):
+        for task_id, task in self.active_tasks.items():
+            task.iteration_status = QUEUED
 
-            # write output
-            self.data_writer()
+    def _set_task_status(self):
+        for task_id, task in tasks_obj.items():
+            if not task.data_exists:
+                task.status = ACTIVATED
+                self.active_tasks[task_id] = task
+                for input_task in task.input_tasks:
+                    input_task.status = ACTIVATED
+                    self.active_tasks[input_task.task_id] = input_task
+    
+    def _get_source_tasks(self):
+        for task_id, task in self.active_tasks.items():
+            if task.data_exists or len(task.input_tasks) == 0:
+                self.source_tasks[task_id] = task
+                task.task_type = SOURCE
+    
+    def _activate_tasks(self):
+        for task_id, task in self.source_tasks.items():
+            task.activate()
+            if task.output_element['timestamp'] != self.current_timestamp:
+                raise Exception(f'''
+                    source timestamp {task.output_element["timestamp"]} 
+                    of {task_id} does not match current_timstamp {self.current_timestamp}
+                ''')
 
-            # log source state
-            if self.logging:
-                self._write_log()
-            
-            # Print progress
-            self.elements_complete += 1
-            next_percent_complete = round(100 * self.elements_complete / self.total_elements)
-            if next_percent_complete > self.percent_complete and (next_percent_complete < 100 \
-                or self.elements_complete == 100):
-                print(f'{str(next_percent_complete)}%', flush=True)
-                self.percent_complete = next_percent_complete
-            
-            for output_op in self.output_tasks:
-                if element is None:
-                    self.data_writer(flush=True)
-                    if self.logging:
-                        self._close_log()
-                    print(f'{self.table} has been flushed')
-                    output_op.kill_all()
-                else:
-                    output_op.activate()
-            
+    def _update_progress(self):
+        self.elements_complete += 1
+        next_percent_complete = round(100 * self.elements_complete / self.total_elements)
+        if next_percent_complete > self.percent_complete and (next_percent_complete < 100 \
+            or self.elements_complete == 100):
+            print(f'{str(next_percent_complete)}%', flush=True)
+            self.percent_complete = next_percent_complete
+    

--- a/trading/pipeline/configs/config.py
+++ b/trading/pipeline/configs/config.py
@@ -1,16 +1,16 @@
 local_env_data = './data'
 symbols = ['BTCUSD']
 timeframes = [
-    '1m',
+    # '1m',
     '5m',
-    '15m',
+    # '15m',
     # '30m',
-    '1h',
+    # '1h',
     # '2h',
-    '4h',
+    # '4h',
     # '6h',
     # '12h',
-    '1D',
+    # '1D',
     # '2D',
 ]
 base_timeframe = '1m'
@@ -105,7 +105,7 @@ schema = {
     ]
 }
 dev_hist_start = '2022-01-01'
-dev_hist_end = '2023-03-01'
+dev_hist_end = '2022-03-01'
 bitfinex = {
     'base_url': 'https://api-pub.bitfinex.com/v2',
     'candle_url': {

--- a/trading/pipeline/configs/task_config.py
+++ b/trading/pipeline/configs/task_config.py
@@ -1,0 +1,14 @@
+# status
+UNACTIVATED = 0
+DEACTIVATED = 1
+ACTIVATED = 2
+
+# task type
+TASK = 0
+SOURCE = 1
+
+# iteration status
+IDLE = 0
+QUEUED = 1
+IN_PROGRESS = 2
+COMPLETE = 3

--- a/trading/pipeline/pipeline.py
+++ b/trading/pipeline/pipeline.py
@@ -16,6 +16,8 @@ from pipeline.steps.transformers.high_low_history import HighLowHistory
 
 import os
 
+from pipeline.base_classes.source import Source
+
 
 def run(pipeline_id):
     os.environ['PIPELINE_ID'] = str(pipeline_id)
@@ -77,12 +79,16 @@ def run(pipeline_id):
                 history_length=10,
             )
 
-            # Organise dependencies
+            # set dependencies
             fetch_candles[s] >> aggregate_candles[s][t] >> [high_low[s][t], rsi[s][t]]
             high_low[s][t] >> [resistance[s][t], support[s][t]]
             [aggregate_candles[s][t], high_low[s][t]] >> high_low_history[s][t]
             [aggregate_candles[s][t], high_low_history[s][t]] >> retracement[s][t]
 
     
-    for s in config.symbols:
-        fetch_candles[s].activate()
+    # for s in config.symbols:
+    #     fetch_candles[s].activate()
+
+    source = Source()
+    source.start_source()
+    

--- a/trading/pipeline/steps/candles/fetch_candles.py
+++ b/trading/pipeline/steps/candles/fetch_candles.py
@@ -2,12 +2,12 @@ import requests
 from pipeline.utils.utils import date_str_to_timestamp, timeframe_to_ms
 from pipeline.configs import config
 import time
-from pipeline.base_classes.source import Source
+from pipeline.base_classes.task import Task
 from copy import deepcopy
 import os
 
 
-class FetchCandles(Source):
+class FetchCandles(Task):
     def __init__(self, *args, **kwargs):
         self.__dict__.update(kwargs)
         self.url = config.bitfinex['candle_url'][self.symbol]
@@ -15,6 +15,7 @@ class FetchCandles(Source):
         self.interval = config.base_ms
         self.last_candle = None
         super().__init__()
+        self.convert_data_source_to_generator()
 
     def generate(self):
         # Fetch candles in batches


### PR DESCRIPTION
Addressing issue #49.

- Tasks can now read directly from database if data already exists
- Tasks only become active (status = `ACTIVATED`) if the data does not exist OR if an output task depends on it
- Tasks can have a `DEACTIVATED` status if the data already exists and no tasks depend on it